### PR TITLE
add OpenFOAM case directory wrapper and examples

### DIFF
--- a/cusfsim/case.py
+++ b/cusfsim/case.py
@@ -1,0 +1,291 @@
+"""
+This module allows the building and manipulating OpenFOAM case directories.
+
+OpenFOAM files are mapped into Python objects using the following conventions:
+
+  * Dictionaries map to python :py:class:`dict`.
+  * Keyword data entries map to :py:class:`tuple` when the number of data
+    entries is greater than one. Otherwise the single data entry is the
+    keyword's value.
+  * Lists are mapped to Python :py:class:`list`.
+  * Dimension are represented via the :py:class:`~.Dimension` type.
+
+"""
+import contextlib
+import enum
+import os
+
+import PyFoam.Basics.DataStructures as PFDataStructs
+from PyFoam.Execution.BasicRunner import BasicRunner
+from PyFoam.RunDictionary.ParsedParameterFile import (
+    ParsedParameterFile, WriteParameterFile
+)
+
+## EXCEPTIONS
+
+class CaseException(Exception):
+    """Base class for exceptions raised by cusfsim.case module."""
+
+class CaseDoesNotExist(CaseException):
+    """A case directory did not exist when we expected it to."""
+
+class CaseToolRunFailed(CaseException):
+    """There was a failure running a tool on a case directory."""
+
+## ENUMERATIONS
+
+def _sys_path(p):
+    return os.path.join('system', p)
+
+def _constant_path(p):
+    return os.path.join('constant', p)
+
+class FileName(enum.Enum):
+    """An enumeration of well known OpenFOAM file locations."""
+
+    #: controlDict
+    CONTROL                 = _sys_path('controlDict')
+
+    #: blockMeshDict
+    BLOCK_MESH              = _sys_path('blockMeshDict')
+
+    #: fvSolution
+    FV_SOLUTION             = _sys_path('fvSolution')
+
+    #: fvSchemes
+    FV_SCHEMES              = _sys_path('fvSchemes')
+
+    #: transportProperties
+    TRANSPORT_PROPERTIES    = _constant_path('transportProperties')
+
+class Dimension(PFDataStructs.Dimension):
+    """Represents a value's dimensions in OpenFOAM cases.
+
+    >>> d = Dimension(0, 1, -2, 0, 0, 0, 0)
+    >>> str(d) # PyFOAM data file representation
+    '[ 0 1 -2 0 0 0 0 ]'
+    >>> d.unit
+    'ms^-2'
+    >>> repr(d)
+    'cusfsim.case.Dimension(0, 1, -2, 0, 0, 0, 0)'
+
+    It supports indexing and the sequence property
+
+    >>> d[2]
+    -2
+    >>> [v+1 for v in d]
+    [1, 2, -1, 1, 1, 1, 1]
+    >>> d[0] = 2
+    >>> d.unit
+    'kg^2ms^-2'
+
+    """
+
+    _SI_UNIT_NAMES = ['kg', 'm', 's', 'K', 'mol', 'A', 'cd']
+
+    @property
+    def unit(self):
+        combined = []
+        for unit, value in zip(Dimension._SI_UNIT_NAMES, self):
+            if value == 0:
+                continue
+            combined.append(unit)
+            if value != 1:
+                combined.append('^{}'.format(value))
+        return ''.join(combined)
+
+    def __repr__(self):
+        return ''.join([
+            str(self.__class__.__module__), '.',
+            str(self.__class__.__name__), '(',
+            ', '.join([str(v) for v in self]), ')'
+        ])
+
+# Monkey-patch PyFOAM to ensure our Dimension type is returned from parsing
+# functions. This is not terribly elegant to say the least and isn't documented
+# but cusfsim tries very hard to hide PyFOAM's API from the user.
+def _monkey_patch_pyfoam():
+    from PyFoam.Basics.FoamFileGenerator import FoamFileGenerator
+    from PyFoam.RunDictionary import ParsedParameterFile
+    PFDataStructs.Dimension = Dimension
+    FoamFileGenerator.Dimension = Dimension
+    FoamFileGenerator.primitiveTypes.extend([Dimension])
+    ParsedParameterFile.Dimension = Dimension
+_monkey_patch_pyfoam()
+
+class FileClass(enum.Enum):
+    """Well known OpenFOAM dictionary classes."""
+
+    #: A parameter dictionary
+    DICTIONARY = "dictionary"
+
+    #: A 3D scalar field
+    SCALAR_FIELD_3D = "volScalarField"
+
+    #: A 3D vector field
+    VECTOR_FIELD_3D = "volVectorField"
+
+## PUBLIC CLASSES AND FUNCTIONS
+
+def read_data_file(path):
+    """Read and parse an OpenFOAM dict into a Python dictionary.
+
+    Args:
+        path (str): path to the OpenFOAM dict on disk
+
+    Returns:
+        A dict representing a Python transliteration of the dict.
+
+    Raises:
+        IOError: the path could not be read from
+    """
+    return ParsedParameterFile(path).content
+
+
+class Case(object):
+    """Object representing an OpenFOAM case on disk.
+
+    Attributes:
+        root_dir_path: path to case directory
+    """
+
+    def __init__(self, root_dir_path, create=True):
+        """Initialises an OpenFOAM case from an on-disk path.
+
+        The case directory may optionally be created if it does not exist. If
+        create is False, a CaseDoesNotExist exception will be raised.
+
+        Args:
+            root_dir_path (str): Path to the OpenFOAM case.
+            create (bool): Create the case if it doesn't exist.
+
+        """
+        # ensure directory exists if asked
+        if create:
+            os.makedirs(root_dir_path)
+
+        # check directory exists
+        if not os.path.isdir(root_dir_path):
+            raise CaseDoesNotExist(
+                'Is not a directory: {}'.format(root_dir_path)
+            )
+
+        # set attributes
+        self.root_dir_path = root_dir_path
+
+    def mutable_data_file(self, path,
+                     create_class=FileClass.DICTIONARY, create=True):
+        """A context manager representing a dict. Changes to the dict are
+        written back to disk.
+
+        Args:
+            path (str or FileName): relative path to dictionary
+            create_class (str or FileClass): specify the class of created files
+            create (bool): create file if it does not exist
+
+        >>> case = getfixture('tmpcase')
+        >>> with case.mutable_data_file('system/blockMeshDict') as d:
+        ...     d['boundary'] = { 'foo': { 'type': 'empty' } }
+        >>> case.read_data_file('system/blockMeshDict')['boundary']['foo']
+        {'type': 'empty'}
+
+        >>> case = getfixture('tmpcase')
+        >>> items = { 'application': 'simpleFoam', 'description': 'mycase' }
+        >>> with case.mutable_data_file(FileName.CONTROL) as d:
+        ...     d.update(items)
+        >>> control = case.read_data_file(FileName.CONTROL)
+        >>> control['application']
+        'simpleFoam'
+        >>> control['description']
+        'mycase'
+
+        """
+        return _mutable_data_file_manager(
+            self._get_rel_path(_to_dict_path(path)),
+            create_class=create_class, create=create
+        )
+
+    def read_data_file(self, path):
+        """Read the contents of the control dictionary.
+
+        Args:
+            path (str or FileName): relative path to dictionary
+
+        Raises:
+            IOError: the control dictionary could not be opened
+
+        """
+        return read_data_file(self._get_rel_path(_to_dict_path(path)))
+
+    def run_tool(self, tool_name):
+        """Run an OpenFOAM tool on the case.
+
+        It is assumed that the tool accepts the standard "-case" argument.
+
+        Args:
+            tool_name (str): name of tool to run (e.g. "icoFoam")
+
+        Raises:
+            CaseToolRunFailed: if the tool exits with an error
+        """
+        logname = 'log.{}'.format(tool_name)
+        runner = BasicRunner(
+            [tool_name, '-case', self.root_dir_path],
+            silent=True, logname=logname
+        )
+        runner.start()
+        if not runner.runOK():
+            raise CaseToolRunFailed('Tool "{}" failed'.format(tool_name))
+
+    def _get_rel_path(self, path):
+        """Return path relative to root directory."""
+        return os.path.join(self.root_dir_path, path)
+
+## PRIVATE CLASSES AND FUNCTIONS
+
+@contextlib.contextmanager
+def _mutable_data_file_manager(path, create_class=FileClass.DICTIONARY, 
+                               create=True):
+    """Context manager for mutating an OpenFOAM dict.
+
+    If the dictionary is created, create_class is used to specify the class of
+    the created dictionary.
+
+    >>> dict_path = getfixture('tmpdir').join('tmpDict').strpath
+    >>> with _mutable_data_file_manager(dict_path, create=True) as d:
+    ...     d['test'] = 'foo'
+    >>> read_data_file(dict_path)['test']
+    'foo'
+
+    Args:
+        path (str): path to OpenFOAM dict
+        create_class (str or FileClass): specify the class of created files
+        create (bool): create file if it does not exist
+
+    Returns:
+        A context manager which reads (or optionally creates) an OpenFOAM dict
+        file, returns a Python representation. When the context is left, the
+        content is written back to disk.
+
+    """
+    if create and not os.path.isfile(path):
+        dir_path = os.path.dirname(path)
+        if not os.path.isdir(dir_path):
+            os.makedirs(dir_path)
+
+        try:
+            create_class = create_class.value
+        except AttributeError:
+            create_class = create_class
+
+        foam_file = WriteParameterFile(path, className=create_class)
+    else:
+        foam_file = ParsedParameterFile(path)
+    yield foam_file.content
+    foam_file.writeFile()
+
+def _to_dict_path(path_or_dict_name):
+    try:
+        return path_or_dict_name.value
+    except AttributeError:
+        return path_or_dict_name

--- a/cusfsim/conftest.py
+++ b/cusfsim/conftest.py
@@ -1,0 +1,17 @@
+"""Configuration for pytest.
+
+Put any global scope fixtures in this file. Fixtures defined in this file are
+available to doctest tests via the "getfixture" function.
+
+"""
+import pytest
+
+@pytest.fixture
+def tmpcase(tmpdir):
+    """An empty Case instance which has been created in a temporary directory.
+
+    """
+    from cusfsim.case import Case
+    case_dir = tmpdir.join('temp_case')
+    return Case(case_dir.strpath)
+

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -1,0 +1,6 @@
+Usage examples
+==============
+
+This section documents the example scripts shipped with the source code.
+
+.. include:: ../examples/openfoam_cavity_tutorial.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,6 +4,7 @@
 .. toctree::
    :hidden:
 
+   examples
    reference
 
 CU Spaceflight Simulation Software

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1,9 +1,15 @@
 Reference
 =========
 
+OpenFOAM case directory manipulation
+------------------------------------
+
+.. automodule:: cusfsim.case
+   :members:
+
 Fin-flutter
 -----------
 
 .. automodule:: cusfsim.finflutter
-    :members:
+   :members:
 

--- a/examples/openfoam_cavity_tutorial.py
+++ b/examples/openfoam_cavity_tutorial.py
@@ -1,0 +1,200 @@
+"""
+Example which re-creates the OpenFOAM cavity tutorial case.
+
+>>> import os
+>>> case_dir = os.path.join(getfixture('tmpdir').strpath, 'cavity')
+>>> main(case_dir)
+>>> os.path.isdir(os.path.join(case_dir, '0.5'))
+True
+
+"""
+import os
+
+from cusfsim.case import (
+    Case, Dimension, FileName, FileClass
+)
+
+def main(case_dir='cavity'):
+    # Create a new case file, raising RuntimeError if the directory already
+    # exists.
+    case = create_new_case(case_dir)
+
+    # Add the information needed by blockMesh.
+    write_initial_control_dict(case)
+    write_block_mesh_dict(case)
+
+    # At this point there is enough to run blockMesh.
+    case.run_tool('blockMesh')
+
+    # Update the physical properties.
+    with case.mutable_data_file(FileName.TRANSPORT_PROPERTIES) as tp:
+        tp['nu'] = (Dimension(0, 2, -1, 0, 0, 0, 0), 0.01)
+
+    # Write the fvSolution and fvSchemes files.
+    write_fv_solution(case)
+    write_fv_schemes(case)
+
+    # Write the initial conditions for the p and U fields.
+    write_initial_conditions(case)
+
+    # Run the icoFoam application.
+    case.run_tool('icoFoam')
+
+def create_new_case(case_dir):
+    # Check that the specified case directory does not already exist
+    if os.path.exists(case_dir):
+        raise RuntimeError(
+            'Refusing to write to existing path: {}'.format(case_dir)
+        )
+
+    # Create the case
+    return Case(case_dir)
+
+def write_initial_control_dict(case):
+    # Control dict from tutorial
+    control_dict = {
+        'application': 'icoFoam',
+        'startFrom': 'startTime',
+        'startTime': 0,
+        'stopAt': 'endTime',
+        'endTime': 0.5,
+        'deltaT': 0.005,
+        'writeControl': 'timeStep',
+        'writeInterval': 20,
+        'purgeWrite': 0,
+        'writeFormat': 'ascii',
+        'writePrecision': 6,
+        'writeCompression': 'off',
+        'timeFormat': 'general',
+        'timePrecision': 6,
+        'runTimeModifiable': True,
+    }
+
+    with case.mutable_data_file(FileName.CONTROL) as d:
+        d.update(control_dict)
+
+def write_block_mesh_dict(case):
+    block_mesh_dict = {
+        'convertToMeters': 0.1,
+
+        'vertices': [
+            [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
+            [0, 0, 0.1], [1, 0, 0.1], [1, 1, 0.1], [0, 1, 0.1],
+        ],
+
+        'blocks': [
+            (
+                'hex', [0, 1, 2, 3, 4, 5, 6, 7], [20, 20, 1],
+                'simpleGrading', [1, 1, 1],
+            )
+        ],
+
+        'edges': [],
+
+        # Note the odd way in which boundary is defined here as a
+        # list of tuples.
+        'boundary': [
+            ('movingWall', {
+                'type': 'wall',
+                'faces': [ [3, 7, 6, 2] ],
+            }),
+            ('fixedWalls', {
+                'type': 'wall',
+                'faces': [
+                    [0, 4, 7, 3],
+                    [2, 6, 5, 1],
+                    [1, 5, 4, 0],
+                ],
+            }),
+            ('frontAndBack', {
+                'type': 'empty',
+                'faces': [
+                    [0, 3, 2, 1],
+                    [4, 5, 6, 7],
+                ],
+            }),
+        ],
+
+        'mergePatchPairs': [],
+    }
+
+    with case.mutable_data_file(FileName.BLOCK_MESH) as d:
+        d.update(block_mesh_dict)
+
+def write_fv_solution(case):
+    fv_solution = {
+        'solvers': {
+            'p': {
+                'solver': 'PCG',
+                'preconditioner': 'DIC',
+                'tolerance': 1e-6,
+                'relTol': 0,
+            },
+            'U': {
+                'solver': 'smoothSolver',
+                'smoother': 'symGaussSeidel',
+                'tolerance': 1e-5,
+                'relTol': 0,
+            },
+        },
+        'PISO': {
+            'nCorrectors': 2,
+            'nNonOrthogonalCorrectors': 0,
+            'pRefCell': 0,
+            'pRefValue': 0,
+        }
+    }
+
+    with case.mutable_data_file(FileName.FV_SOLUTION) as d:
+        d.update(fv_solution)
+
+def write_fv_schemes(case):
+    fv_schemes = {
+        'ddtSchemes': { 'default': 'Euler' },
+        'gradSchemes': { 'default': 'Gauss linear', 'grad(p)': 'Gauss linear' },
+        'divSchemes': { 'div(phi,U)': 'Gauss linear', 'default': 'none' },
+        'laplacianSchemes': { 'default': 'Gauss linear orthogonal' },
+        'interpolationSchemes': { 'default': 'linear' },
+        'snGradSchemes': { 'default': 'orthogonal' },
+    }
+
+    with case.mutable_data_file(FileName.FV_SCHEMES) as d:
+        d.update(fv_schemes)
+
+def write_initial_conditions(case):
+    # Create the p initial conditions
+    p_file = case.mutable_data_file(
+        '0/p', create_class=FileClass.SCALAR_FIELD_3D
+    )
+    with p_file as p:
+        p.update({
+            'dimensions': Dimension(0, 2, -2, 0, 0, 0, 0),
+            'internalField': ('uniform', 0),
+            'boundaryField': {
+                'movingWall': { 'type': 'zeroGradient' },
+                'fixedWalls': { 'type': 'zeroGradient' },
+                'frontAndBack': { 'type': 'empty' },
+            },
+        })
+
+    # Create the U initial conditions
+    U_file = case.mutable_data_file(
+        '0/U', create_class=FileClass.VECTOR_FIELD_3D
+    )
+    with U_file as U:
+        U.update({
+            'dimensions': Dimension(0, 1, -1, 0, 0, 0, 0),
+            'internalField': ('uniform', [0, 0, 0]),
+            'boundaryField': {
+                'movingWall': {
+                    'type': 'fixedValue', 'value': ('uniform', [1, 0, 0])
+                },
+                'fixedWalls': {
+                    'type': 'fixedValue', 'value': ('uniform', [0, 0, 0])
+                },
+                'frontAndBack': { 'type': 'empty' },
+            },
+        })
+
+if __name__ == '__main__':
+    main()

--- a/examples/openfoam_cavity_tutorial.rst
+++ b/examples/openfoam_cavity_tutorial.rst
@@ -1,0 +1,89 @@
+.. This file is read by doc/examples.rst and inserted into the documentation. It
+   lives here so that it is more clearly associated with
+   openfoam_cavity_tutorial.py. Note that file paths are, however, relative to
+   the doc/ directory.
+
+Lid-driven cavity flow
+----------------------
+
+The :download:`openfoam_cavity_tutorial.py <../examples/openfoam_cavity_tutorial.py>`
+script provides an example of low-level manipulation of OpenFOAM cases. In this
+example we shall re-create the `initial example`_ from the OpenFOAM users'
+guide. It's worth reading over that section first before trying to follow the
+transliteration below.
+
+.. _initial example: http://cfd.direct/openfoam/user-guide/cavity/#x5-40002.1
+
+Firstly, we need to import some things from the :py:mod:`cusfsim.case` module::
+
+   from cusfsim.case import Case, FileName, FileClass
+
+The :py:class:`~.case.Case` class encapsulates an OpenFOAM case
+directory. We don't want to overwrite an existing case and so we write a little
+convenience wrapper function:
+
+.. literalinclude:: ../examples/openfoam_cavity_tutorial.py
+   :pyobject: create_new_case
+
+The :py:meth:`~.case.Case.mutable_data_file` method will return a *context
+manager* which can be used to manipulate an OpenFOAM data file. The data file is
+created if it does not yet exist, its contents are parsed into a dictionary and
+the dictionary is returned from the context manager. One the context is left the
+dictionary is re-written to disk.
+
+The upshot of this is that the programmer is insulated from manipulating
+OpenFOAM data files directly. Let's write the *controlDict* file from the
+tutorial:
+
+.. literalinclude:: ../examples/openfoam_cavity_tutorial.py
+   :pyobject: write_initial_control_dict
+
+Well-known file names are available through the :py:class:`~.case.FileName`
+class.
+
+The *blockMeshDict* file is the next one to be created. This is an example of a
+relatively complex file. The complexity is somewhat hidden by the mapping to and
+from the Python domain but there is still some subtlety. Notice particularly the
+rather odd way in which the *boundary* dictionary is specified:
+
+.. literalinclude:: ../examples/openfoam_cavity_tutorial.py
+   :pyobject: write_block_mesh_dict
+
+
+At this point in the tutorial we're ready to run the *blockMesh* command which
+is one function call away::
+
+   case.run_tool('blockMesh')
+
+We're close to being able to run the *icoFoam* utility. The transport properties
+need to be defined::
+
+   from cusfsim.case import Dimension
+
+   with case.mutable_data_file(FileName.TRANSPORT_PROPERTIES) as tp:
+      tp['nu'] = (Dimension(0, 2, -1, 0, 0, 0, 0), 0.01)
+
+We also need to create the initial conditions. Notice that we have to specify a
+different class when creating them:
+
+.. literalinclude:: ../examples/openfoam_cavity_tutorial.py
+   :pyobject: write_initial_conditions
+
+Before we can run *icoFoam*, we must create the mysterious *fvSolution* file:
+
+.. literalinclude:: ../examples/openfoam_cavity_tutorial.py
+   :pyobject: write_fv_solution
+
+And also the equally mysterious *fvSchemes* file:
+
+.. literalinclude:: ../examples/openfoam_cavity_tutorial.py
+   :pyobject: write_fv_schemes
+
+The example script includes a :py:func:`main` function which performs all of
+these steps:
+
+.. literalinclude:: ../examples/openfoam_cavity_tutorial.py
+   :pyobject: main
+
+After the example script is run, *paraFoam* may be run to inspect the solution.
+

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     # tools.
     install_requires=[
         'numpy',
+        'PyFOAM',
     ] + enum_requires,
 
     # Metadata for PyPI (https://pypi.python.org).

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,15 @@
 Setup configuration for installation via pip, easy_install, etc.
 
 """
+import sys
 from setuptools import setup, find_packages
+
+# Python 3.4+ comes with enum.Enum. For prior Pythons, we can install the enum34
+# package from PyPI.
+if sys.hexversion < 0x030400F0:
+    enum_requires = ['enum34']
+else:
+    enum_requires = []
 
 # The find_packages function does a lot of the heavy lifting for us w.r.t.
 # discovering any Python packages we ship.
@@ -15,7 +23,7 @@ setup(
     # tools.
     install_requires=[
         'numpy',
-    ],
+    ] + enum_requires,
 
     # Metadata for PyPI (https://pypi.python.org).
     description='Utilities for rocketry simulation',

--- a/test/test_basic_import.py
+++ b/test/test_basic_import.py
@@ -5,3 +5,6 @@ def test_basic_import():
 
 def test_finflutter_import():
     import cusfsim.finflutter
+
+def test_case_import():
+    import cusfsim.case

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -1,0 +1,64 @@
+"""
+Test OpenFOAM case handling.
+
+"""
+import os
+
+import pytest
+
+from cusfsim.case import (
+    Case, CaseDoesNotExist, Dimension, FileName, FileName, read_data_file
+)
+
+@pytest.fixture
+def tmpcase(tmpdir):
+    """An empty Case instance which has been created in a temporary directory.
+
+    """
+    from cusfsim.case import Case
+    case_dir = tmpdir.join('temp_case')
+    return Case(case_dir.strpath)
+
+def _read_foam_dict(path):
+    """Read foam dict file at path and return content."""
+    return ParsedParameterFile(path).content
+
+def test_case_must_exist(tmpdir):
+    """If create is False, the case directory must exist."""
+    case_dir = tmpdir.join('does_not_exist')
+    assert not case_dir.check()
+    with pytest.raises(CaseDoesNotExist):
+        Case(case_dir.strpath, create=False)
+
+def test_case_created(tmpdir):
+    """If create is True, the case directory is created."""
+    case_dir = tmpdir.join('does_not_exist')
+    assert not case_dir.check()
+    Case(case_dir.strpath)
+    assert case_dir.check()
+
+def test_write_control_dict(tmpcase):
+    """Writing to a mutable control dict should be reflected on disk."""
+    with tmpcase.mutable_data_file(FileName.CONTROL) as control:
+        control['testing'] = 'oneTwoThree'
+    dict_path = os.path.join(tmpcase.root_dir_path, 'system', 'controlDict')
+    assert os.path.isfile(dict_path)
+    content = read_data_file(dict_path)
+    assert 'testing' in content
+    assert content['testing'] == 'oneTwoThree'
+
+def test_read_data_file_needs_file(tmpdir):
+    """Reading a non-existent dictionary file raises."""
+    pn = tmpdir.join('noSuchDict').strpath
+    assert not os.path.isfile(pn)
+    with pytest.raises(IOError):
+        read_data_file(pn)
+
+def test_dimension_type_preserved(tmpcase):
+    dims = Dimension(1, 2, 3, 4, 5, 6, 7)
+    with tmpcase.mutable_data_file('test') as d:
+        d['foo'] = dims
+    d = tmpcase.read_data_file('test')
+    assert d['foo'] == dims
+    print(type(d['foo']))
+    assert isinstance(d['foo'], Dimension)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,11 @@ envlist=py27-test,py3-test,py27-examples,py3-examples,docs
 basepython=
     py27: python2.7
     py3: python3
+
+# We need to pass the FOAM_ and WM_ environment variables into the testenv since
+# these are set by the OpenFOAM etc/bashrc script.
+passenv=FOAM_* WM_*
+
 # Our test suite is based on py.test. Allow passing arguments to py.test from
 # the tox command line via {posargs}.
 deps=


### PR DESCRIPTION
The first bit of CFD functionality(!) The idea of this PR is to provide a simple programmatic interface to the OpenFOAM system. Ideally we'll be able to write little Python scripts to set up cases or run them.

This first PR sets up the infrastructure to create a case directory, load and save the OpenFOAM data files within it and run OpenFOAM tools. This is exposed in the cusfsim.case module. Tests and documentation are provided.

In addition to the API tests, a full example is also included. This is a transliteration of the OpenFOAM lid-driven cavity flow example and provides an indication of the sort of Python scripts we can write. Instead of the configuration being split over multiple files, a single script can create he configuration and, in the fullness of time, the script may be able to vary parameters.

This PR is an instance of "example driven development" in that I wrote the examples/openfoam_cavity_tutorial.py script first with the API I thought would be convenient. I then fleshed out the cusfsim.case module to implement it.

The example is documented in the sphinx documentation function-by-function and is also run as part of the travis test procedure.