### PR TITLE
add coveralls.io configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ sdist
 .tox
 .cache
 
+# Code-coverage output
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,9 @@ matrix:
       env: TOX_ENV=docs
 dist: trusty
 sudo: true
-install: scripts/travis-install.sh
+install:
+  - pip install coveralls
+  - scripts/travis-install.sh
 script: scripts/travis-run-tests.sh
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # m3cfd
 
 [![Build Status](https://travis-ci.org/cuspaceflight/m3cfd.svg?branch=master)](https://travis-ci.org/cuspaceflight/m3cfd)
+[![Coverage
+Status](https://coveralls.io/repos/cuspaceflight/m3cfd/badge.svg?branch=master&service=github)](https://coveralls.io/github/cuspaceflight/m3cfd?branch=master)
 
 CFD simulation software for Martlet 3
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
 # List any specific packages required for running the tests here.
-
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps=
     py{27,3}-test: -rtest/requirements.txt
     py{27,3}-examples: -rexamples/requirements.txt
 commands=
-    py{27,3}-test: py.test {posargs}
+    py{27,3}-test: py.test --cov=cusfsim/ {posargs}
     py{27,3}-examples: py.test examples
 
 # Configuration specific to the "docs" environment.


### PR DESCRIPTION
coveralls.io is a code-coverage monitoring service. It allows us to keep an eye
on how much of the code is covered by our tests.

This PR adds the small amount of configuration required to upload the code
coverage information to coveralls.io.

See: https://coveralls.io/github/cuspaceflight/m3cfd

Coveralls will also comment on PRs and check that the code coverage of tests
does not fall below a set threshold. (Currently this is 91%.)