### PR TITLE
case: reimplement run_tool

### DIFF
--- a/cusfsim/case.py
+++ b/cusfsim/case.py
@@ -19,7 +19,6 @@ import subprocess
 import tempfile
 
 import PyFoam.Basics.DataStructures as PFDataStructs
-from PyFoam.Execution.BasicRunner import BasicRunner
 from PyFoam.RunDictionary.ParsedParameterFile import (
     ParsedParameterFile, WriteParameterFile
 )
@@ -47,19 +46,19 @@ class FileName(enum.Enum):
     """An enumeration of well known OpenFOAM file locations."""
 
     #: controlDict
-    CONTROL                 = _sys_path('controlDict')
+    CONTROL = _sys_path('controlDict')
 
     #: blockMeshDict
-    BLOCK_MESH              = _sys_path('blockMeshDict')
+    BLOCK_MESH = _sys_path('blockMeshDict')
 
     #: fvSolution
-    FV_SOLUTION             = _sys_path('fvSolution')
+    FV_SOLUTION = _sys_path('fvSolution')
 
     #: fvSchemes
-    FV_SCHEMES              = _sys_path('fvSchemes')
+    FV_SCHEMES = _sys_path('fvSchemes')
 
     #: transportProperties
-    TRANSPORT_PROPERTIES    = _constant_path('transportProperties')
+    TRANSPORT_PROPERTIES = _constant_path('transportProperties')
 
 class Dimension(PFDataStructs.Dimension):
     """Represents a value's dimensions in OpenFOAM cases.
@@ -109,11 +108,11 @@ class Dimension(PFDataStructs.Dimension):
 # but cusfsim tries very hard to hide PyFOAM's API from the user.
 def _monkey_patch_pyfoam():
     from PyFoam.Basics.FoamFileGenerator import FoamFileGenerator
-    from PyFoam.RunDictionary import ParsedParameterFile
+    import PyFoam.RunDictionary.ParsedParameterFile as ParsedParameterFileModule
     PFDataStructs.Dimension = Dimension
     FoamFileGenerator.Dimension = Dimension
     FoamFileGenerator.primitiveTypes.extend([Dimension])
-    ParsedParameterFile.Dimension = Dimension
+    ParsedParameterFileModule.Dimension = Dimension
 _monkey_patch_pyfoam()
 
 class FileClass(enum.Enum):
@@ -177,7 +176,7 @@ class Case(object):
         self.root_dir_path = root_dir_path
 
     def mutable_data_file(self, path,
-                     create_class=FileClass.DICTIONARY, create=True):
+                          create_class=FileClass.DICTIONARY, create=True):
         """A context manager representing a dict. Changes to the dict are
         written back to disk.
 
@@ -258,7 +257,7 @@ class Case(object):
 ## PRIVATE CLASSES AND FUNCTIONS
 
 @contextlib.contextmanager
-def _mutable_data_file_manager(path, create_class=FileClass.DICTIONARY, 
+def _mutable_data_file_manager(path, create_class=FileClass.DICTIONARY,
                                create=True):
     """Context manager for mutating an OpenFOAM dict.
 

--- a/cusfsim/finflutter.py
+++ b/cusfsim/finflutter.py
@@ -44,16 +44,16 @@ def model_atmosphere(altitudes):
     regs[altitudes > 25000] = 3
 
     # Troposphere
-    ts[regs==1] = 15.04 - 0.00649*altitudes[regs==1]
-    ps[regs==1] = 1000 * 101.29*((ts[regs==1] + 273.1)/288.08)**5.256
+    ts[regs == 1] = 15.04 - 0.00649*altitudes[regs == 1]
+    ps[regs == 1] = 1000 * 101.29*((ts[regs == 1] + 273.1)/288.08)**5.256
 
     # Lower Stratosphere
-    ts[regs==2] = -56.46
-    ps[regs==2] = 1000 * 22.65 * np.exp(1.73 - 0.000157*altitudes[regs==2])
+    ts[regs == 2] = -56.46
+    ps[regs == 2] = 1000 * 22.65 * np.exp(1.73 - 0.000157*altitudes[regs == 2])
 
     # Upper Stratosphere
-    ts[regs==3] = -131.21 + 0.00299*altitudes[regs==3]
-    ps[regs==3] = 1000 * 2.488 * ((ts[regs==3] + 273.1) / 216.6)**-11.388
+    ts[regs == 3] = -131.21 + 0.00299*altitudes[regs == 3]
+    ps[regs == 3] = 1000 * 2.488 * ((ts[regs == 3] + 273.1) / 216.6)**-11.388
 
     # "from Hyperphysics"
     ss = 331.3 * np.sqrt(1 + (ts / 273.15))

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -65,11 +65,11 @@ def test_dimension_type_preserved(tmpcase):
     assert isinstance(d['foo'], Dimension)
 
 def test_run_tool(tmpcase):
-    """Simple incovation of run_tool succeeds."""
+    """Simple invocation of run_tool succeeds."""
     tmpcase.run_tool('foamInfoExec')
 
 def test_run_tool_needs_tool_to_exist(tmpcase):
-    """Simple incovation of run_tool fails for a non-existent tool."""
+    """Simple invocation of run_tool fails for a non-existent tool."""
     with pytest.raises(OSError):
         tmpcase.run_tool('thatsNoTool')
 

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -68,6 +68,11 @@ def test_run_tool(tmpcase):
     """Simple incovation of run_tool succeeds."""
     tmpcase.run_tool('foamInfoExec')
 
+def test_run_tool_needs_tool_to_exist(tmpcase):
+    """Simple incovation of run_tool fails for a non-existent tool."""
+    with pytest.raises(OSError):
+        tmpcase.run_tool('thatsNoTool')
+
 def test_run_tool_needs_tool_to_succeed(tmpcase):
     """Trying to run a tool which fails raises an error."""
     # Running blockMesh with no blockMeshDict fails

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -7,7 +7,8 @@ import os
 import pytest
 
 from cusfsim.case import (
-    Case, CaseDoesNotExist, Dimension, FileName, FileName, read_data_file
+    Case, CaseDoesNotExist, Dimension, FileName, FileName, read_data_file,
+    CaseToolRunFailed
 )
 
 @pytest.fixture
@@ -62,3 +63,13 @@ def test_dimension_type_preserved(tmpcase):
     assert d['foo'] == dims
     print(type(d['foo']))
     assert isinstance(d['foo'], Dimension)
+
+def test_run_tool(tmpcase):
+    """Simple incovation of run_tool succeeds."""
+    tmpcase.run_tool('foamInfoExec')
+
+def test_run_tool_needs_tool_to_succeed(tmpcase):
+    """Trying to run a tool which fails raises an error."""
+    # Running blockMesh with no blockMeshDict fails
+    with pytest.raises(CaseToolRunFailed):
+        tmpcase.run_tool('blockMesh')


### PR DESCRIPTION
The first pass at run_tool was a thin wrapper around PyFOAM's tool runner. This had some drawbacks:

* run_tool would silently do nothing if the tool did not exist
* the log files were not robustly created to avoid duplication
* (at least on my machine) sometimes the runner would lose track of the process and fail with an error about being unable to open the process' corresponding entry under ``/proc``

Python already has a standard system for spawning subprocesses, the ``subprocess`` module. For our basic needs, the PyFOAM runner was overkill. Replace the run_tool implementation with a simpler one based on ``subprocess`` which addresses the issues above.

(**Note:** the coveralls check, if present, will probably fail for this PR since #10 has not yet been merged.)