### PR TITLE
doc: add matplotlib sphinx extension to allow embedding plots

### DIFF
--- a/cusfsim/finflutter.py
+++ b/cusfsim/finflutter.py
@@ -1,7 +1,32 @@
 """
 Calculation of fin flutter vs. altitude.
 
-FIXME: document where this comes from and how it is derived.
+.. todo::
+
+    document where this comes from and how it is derived.
+
+This module provides a simple API for computing fin-flutter velocity as a
+function of altitude. These can then be plotted. For example:
+
+.. plot::
+    :include-source:
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from cusfsim import finflutter
+
+    zs = np.linspace(0, 50000, 200)
+    ps, _, ss = finflutter.model_atmosphere(zs)
+    vs = finflutter.flutter_velocity(
+        ps, ss, root_chord=20, tip_chord=10, semi_span=10, thickness=0.2
+    )
+
+    plt.plot(zs * 1e-3, vs)
+    plt.grid()
+    plt.title('Flutter velocity versus altitude')
+    plt.xlabel('Altitude [km]')
+    plt.ylabel('Flutter velocity [ms${}^{-1}$]')
+    plt.show()
 
 """
 # Make sure a/b does what we expect even if both are integers(!)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'matplotlib.sphinxext.plot_directive',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 # This file lists the requirements for building the cusfsim documentation beyond
 # the basic "sphinx" package.
 recommonmark
+matplotlib
 


### PR DESCRIPTION
It's nice to be able to include plots in the generated documentation. Add the
matplotlib sphinx extensions and provide an example by including the fin-flutter
plot in the generated documentation.