### PR TITLE
Add IO module with support for parsing RockSim .rse files.

### DIFF
--- a/cusfsim/io.py
+++ b/cusfsim/io.py
@@ -1,0 +1,83 @@
+"""
+This module contains IO utility functions for amateur rocketry file formats.
+"""
+import xml.etree.ElementTree as ET
+import collections
+import pandas
+
+class RSEParseError(RuntimeError):
+    """
+    Raised when there is an error parsing a RockSim file.
+    """
+
+_Engine = collections.namedtuple("Engine", ["code", "manufacturer",
+                                            "comments", "data"])
+
+class Engine(_Engine):
+    """
+    An individual engine record.
+
+    The thrust curve data is represented by a pandas DataFrame object, with the
+    following columns: time (seconds), force (Newtons), mass (grams).
+
+    Attributes:
+        manufacturer: A string containing the manufacturer, or None
+        code: A string containing the maufacturer's product code, or None
+        comments: A string containing any comments, or None
+        data: A pandas DataFrame, see above
+    """
+    # See: http://stackoverflow.com/questions/1606436
+    __slots__ = ()
+
+def _get_float_attr(elem, attr, default=None):
+    v = elem.get(attr)
+    if v is None:
+        return default
+    return float(v)
+
+def _parse_engine(engine):
+    comments_elem = engine.find("comments")
+    comments = comments_elem.text if comments_elem is not None else None
+
+    data_elem = _find_or_raise(engine, 'data')
+    data_records = []
+    for datum in data_elem.iterfind("eng-data"):
+        data_records.append((
+            _get_float_attr(datum, "t"),
+            _get_float_attr(datum, "f"),
+            _get_float_attr(datum, "m"),
+        ))
+    data = pandas.DataFrame.from_records(data_records,
+                                         columns=['time', 'force', 'mass'])
+
+    return Engine(code=engine.get("code"), manufacturer=engine.get("mfg"),
+                  comments=comments, data=data)
+
+def _find_or_raise(elem, tag):
+    child = elem.find(tag)
+    if child is None:
+        raise RSEParseError("Could not find expected element: %s" % tag)
+    return child
+
+def rse_load(path):
+    """
+    Load a RockSim format engine database from disk.
+
+    Args:
+        path (str): path name to .rse file
+
+    Returns:
+        A list of Engine instances.
+
+    Raises:
+        RSEParseError: when the .rse file is invalid
+    """
+    tree = ET.parse(path)
+    root = tree.getroot()
+
+    if root.tag != "engine-database":
+        raise RSEParseError("Expected engine-database tag.")
+
+    engine_list = _find_or_raise(root, 'engine-list')
+
+    return [_parse_engine(e) for e in engine_list.iterfind("engine")]

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -7,6 +7,12 @@ OpenFOAM case directory manipulation
 .. automodule:: cusfsim.case
    :members:
 
+IO
+--
+
+.. automodule:: cusfsim.io
+   :members:
+
 Geometry manipulation
 ---------------------
 

--- a/pylintrc
+++ b/pylintrc
@@ -3,7 +3,7 @@
 # which is better addressed via manual code review.
 disable=
     missing-docstring, invalid-name, too-few-public-methods,
-    too-many-arguments, fixme
+    too-many-arguments, fixme, wrong-import-order, redefined-variable-type
 
 # There's an annoying interaction with pylint and numpy which means that pylint
 # tags all attempts at using a numpy function as an attempt to access a

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     install_requires=[
         'numpy',
         'numpy-stl',
+        'pandas',
         'PyFOAM',
     ] + enum_requires,
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,3 +10,8 @@ def datadir():
 def geomdir(datadir):
     """Geometry data directory."""
     return os.path.join(datadir, 'geometry')
+
+@pytest.fixture
+def iodir(datadir):
+    """IO data directory."""
+    return os.path.join(datadir, 'io')

--- a/test/data/io/engine_1.rse
+++ b/test/data/io/engine_1.rse
@@ -1,0 +1,36 @@
+<engine-database>
+  <engine-list>
+    <engine  mfg="CTI" code="614-I100-RL_LB-17A" Type="reloadable" dia="54." len="236."
+initWt="807." propWt="350.1" delays="9,11,12,13,15,17" auto-calc-mass="1"
+auto-calc-cg="1" avgThrust="69.97" peakThrust="332.429" throatDia="0."
+exitDia="0." Itot="629.237" burn-time="8.99" massFrac="43.38" Isp="183.27"
+tDiv="10" tStep="-1." tFix="1" FDiv="10" FStep="-1." FFix="1" mDiv="10"
+mStep="-1." mFix="1" cgDiv="10" cgStep="-1." cgFix="1">
+    <comments>Pro-54-2G Red Lightning Long Burn</comments>
+    <data>
+      <eng-data  t="0." f="0." m="350.1" cg="118."/>
+      <eng-data  t="0.042" f="269.267" m="346.954" cg="118."/>
+      <eng-data  t="0.043" f="332.429" m="346.786" cg="118."/>
+      <eng-data  t="0.07" f="225.102" m="342.599" cg="118."/>
+      <eng-data  t="0.091" f="202.307" m="340.102" cg="118."/>
+      <eng-data  t="0.14" f="234.125" m="334.153" cg="118."/>
+      <eng-data  t="0.202" f="245.522" m="325.88" cg="118."/>
+      <eng-data  t="0.349" f="220.828" m="306.808" cg="118."/>
+      <eng-data  t="0.523" f="202.307" m="286.326" cg="118."/>
+      <eng-data  t="0.837" f="183.311" m="252.641" cg="118."/>
+      <eng-data  t="1.186" f="164.315" m="218.89" cg="118."/>
+      <eng-data  t="1.681" f="139.62" m="177.037" cg="118."/>
+      <eng-data  t="2.358" f="110.651" m="129.901" cg="118."/>
+      <eng-data  t="3.321" f="76.459" m="79.7744" cg="118."/>
+      <eng-data  t="4.095" f="55.563" m="51.3471" cg="118."/>
+      <eng-data  t="4.919" f="37.042" m="30.1191" cg="118."/>
+      <eng-data  t="5.944" f="21.37" m="13.463" cg="118."/>
+      <eng-data  t="6.726" f="12.347" m="6.12794" cg="118."/>
+      <eng-data  t="7.437" f="6.174" m="2.46456" cg="118."/>
+      <eng-data  t="8.142" f="2.849" m="0.694903" cg="118."/>
+      <eng-data  t="8.735" f="0.95" m="0.0681854" cg="118."/>
+      <eng-data  t="8.993" f="0." m="0." cg="118."/>
+    </data>
+  </engine>
+</engine-list>
+</engine-database>

--- a/test/test_basic_import.py
+++ b/test/test_basic_import.py
@@ -11,3 +11,7 @@ def test_case_import():
 
 def test_geometry_import():
     import cusfsim.geometry
+
+def test_io_import():
+	import cusfsim.io
+

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -1,0 +1,47 @@
+import cusfsim.io as cio
+import os
+import pytest
+
+@pytest.fixture
+def engine1(iodir):
+    engine_path = os.path.join(iodir, 'engine_1.rse')
+    return cio.rse_load(engine_path)[0]
+
+def assert_nearly_equal(a, b, tolerance=1e-3):
+    assert abs(a-b) < tolerance
+
+def test_single_load(iodir):
+    engine_path = os.path.join(iodir, 'engine_1.rse')
+    engines = cio.rse_load(engine_path)
+    assert len(engines) == 1
+
+def test_engine_has_code(engine1):
+    assert engine1.code == "614-I100-RL_LB-17A"
+
+def test_engine_has_manufacturer(engine1):
+    assert engine1.manufacturer == "CTI"
+
+def test_engine_has_comments(engine1):
+    assert engine1.comments == "Pro-54-2G Red Lightning Long Burn"
+
+def test_engine_has_data(engine1):
+    assert engine1.data is not None
+
+def test_engine_times_correct(engine1):
+    times = engine1.data['time']
+    assert times.size == 22
+    assert_nearly_equal(times.iloc[0], 0)
+    assert_nearly_equal(times.iloc[-1], 8.993)
+
+def test_engine_forces_correct(engine1):
+    times = engine1.data['force']
+    assert times.size == 22
+    assert_nearly_equal(times.iloc[1], 269.267)
+    assert_nearly_equal(times.iloc[-2], 0.95)
+
+def test_engine_masses_correct(engine1):
+    times = engine1.data['mass']
+    assert times.size == 22
+    assert_nearly_equal(times.iloc[0], 350.1)
+    assert_nearly_equal(times.iloc[-2], 0.0681854)
+


### PR DESCRIPTION
Adds a function rse_load to read a RockSim .rse file containing one or more engine definitions. Output is returned as a list of Engine objects, each containing attributes: manufacturer, code, data.

Data is represented as a pandas DataFrame with columns: time,force, mass.

Adds tests for basic functionality. Does not test malformed input.

Closes #14.