### PR TITLE
Pin pylint version to 1.5.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands=sphinx-build -b html doc/ {envtmpdir}/html
 [testenv:pylint]
 basepython=python2.7
 deps=
-    pylint
+    pylint==1.5.0
     pytest
 commands=pylint cusfsim
 


### PR DESCRIPTION
Pylint will add more checks as time goes on and if a new version of pylint comes
out then tests will start failing which passed before. This is annoying since
PRs like #23 need to add irrelevant pylint fixes just to get the green dot.

Pin pylint at the current released version. This means that a) we won't get any
improvements but b) our tests should continue to pass.

Periodically we should have a "flag-day" where we bump the pylint version.