### PR TITLE
Supersonic wedge example

### DIFF
--- a/examples/openfoam_supersonic_wedge.py
+++ b/examples/openfoam_supersonic_wedge.py
@@ -45,11 +45,6 @@ def write_control_dict(case, n_iter):
     """Sets up the control dictionary.
     In this example we use the rhoCentralFoam compressible solver"""
 
-    if isinstance(n_iter, int) != True:
-        raise RuntimeError(
-                'Number of iterations must be an integer'
-            )
-
     # Control dict from tutorial
     control_dict = {
         'application': 'rhoCentralFoam',

--- a/examples/openfoam_supersonic_wedge.py
+++ b/examples/openfoam_supersonic_wedge.py
@@ -2,8 +2,8 @@
 Example which produces flow over a supersonic wedge
 
 >>> import os
->>> case_dir = os.path.join(getfixture('tmpdir').strpath, 'cavity')
->>> main(case_dir,True)
+>>> case_dir = os.path.join(getfixture('tmpdir').strpath, 'wedge')
+>>> main(case_dir,1)
 >>> os.path.isdir(os.path.join(case_dir, '1'))
 True
 
@@ -14,17 +14,11 @@ from cusfsim.case import (
     Case, Dimension, FileName, FileClass
 )
 
-def main(case_dir='wedge', test_example=False):
+def main(case_dir='wedge', n_iter=10):
     #Try to create new case directory
     case = create_new_case(case_dir)
     # Add the information needed by blockMesh.
-    write_control_dict(case)
-
-    if test_example:
-        #We reduce the end time in order to speed up testing
-        with case.mutable_data_file(FileName.CONTROL) as d:
-            d.update({'endTime' : 1})
-
+    write_control_dict(case, n_iter)
     write_block_mesh_dict(case)
     #we generate the mes1h
     case.run_tool('blockMesh')
@@ -47,9 +41,14 @@ def create_new_case(case_dir):
     #Creates the case
     return Case(case_dir)
 
-def write_control_dict(case):
+def write_control_dict(case, n_iter):
     """Sets up the control dictionary.
     In this example we use the rhoCentralFoam compressible solver"""
+
+    if isinstance(n_iter, (int, long)) != True:
+        raise RuntimeError(
+                'Number of iterations must be an integer'
+            )
 
     # Control dict from tutorial
     control_dict = {
@@ -57,10 +56,10 @@ def write_control_dict(case):
         'startFrom': 'startTime',
         'startTime': 0,
         'stopAt': 'endTime',
-        'endTime': 10,
+        'endTime': n_iter,
         'deltaT': 0.001,
         'writeControl': 'runTime',
-        'writeInterval': 0.5,
+        'writeInterval': 1,
         'purgeWrite': 0,
         'writeFormat': 'ascii',
         'writePrecision': 6,

--- a/examples/openfoam_supersonic_wedge.py
+++ b/examples/openfoam_supersonic_wedge.py
@@ -3,8 +3,8 @@ Example which produces flow over a supersonic wedge
 
 >>> import os
 >>> case_dir = os.path.join(getfixture('tmpdir').strpath, 'cavity')
->>> main(case_dir)
->>> os.path.isdir(os.path.join(case_dir, '10'))
+>>> main(case_dir,True)
+>>> os.path.isdir(os.path.join(case_dir, '1'))
 True
 
 """
@@ -14,11 +14,17 @@ from cusfsim.case import (
     Case, Dimension, FileName, FileClass
 )
 
-def main(case_dir='wedge'):
+def main(case_dir='wedge', test_example=False):
     #Try to create new case directory
     case = create_new_case(case_dir)
     # Add the information needed by blockMesh.
-    write_initial_control_dict(case)
+    write_control_dict(case)
+
+    if test_example:
+        #We reduce the end time in order to speed up testing
+        with case.mutable_data_file(FileName.CONTROL) as d:
+            d.update({'endTime' : 1})
+
     write_block_mesh_dict(case)
     #we generate the mes1h
     case.run_tool('blockMesh')
@@ -41,7 +47,7 @@ def create_new_case(case_dir):
     #Creates the case
     return Case(case_dir)
 
-def write_initial_control_dict(case):
+def write_control_dict(case):
     """Sets up the control dictionary.
     In this example we use the rhoCentralFoam compressible solver"""
 

--- a/examples/openfoam_supersonic_wedge.py
+++ b/examples/openfoam_supersonic_wedge.py
@@ -45,7 +45,7 @@ def write_control_dict(case, n_iter):
     """Sets up the control dictionary.
     In this example we use the rhoCentralFoam compressible solver"""
 
-    if isinstance(n_iter, (int, long)) != True:
+    if isinstance(n_iter, int) != True:
         raise RuntimeError(
                 'Number of iterations must be an integer'
             )

--- a/examples/openfoam_supersonic_wedge.rst
+++ b/examples/openfoam_supersonic_wedge.rst
@@ -18,7 +18,7 @@ compressible solver must therefore be used. In this case we use *rhoCentralFoam*
 control file must therefore be set accordingly:
 
 .. literalinclude:: ../examples/openfoam_supersonic_wedge.py
-   :pyobject: write_initial_control_dict
+   :pyobject: write_control_dict
    
 The mesh needs to be set up using the *blockMeshDict*. The mesh consits of three blocks in order
 to model the upstream and downstream portions as well as the wedge itself. The numbering order in which the 
@@ -32,7 +32,7 @@ describes the order in which the vertices should be listed. The second part of t
 describes the cell density within the block in each of the three directions. The last part is used
 when we want the mesh density to vary within the block.
 
-::_explanation:http://cfd.direct/openfoam/user-guide/blockmesh/
+.. _explanation: http://cfd.direct/openfoam/user-guide/blockmesh/
 
 We must also set the thermodynamic properties of the gas. In this case the properties have been chosen
 so that the gas has a ratio of specific heats of 1.4 and that, if the temperature is 1K, then the speed of sound
@@ -49,7 +49,8 @@ move to a viscous solver we must set a no slip boundary condition on the solid w
    :pyobject: write_initial_conditions
 
 The example script includes a :py:func:`main` function which performs all of
-these steps:
+these steps. A boolean value can be passed to :py:func:`main` in order to reduce the number of iterations
+and so speed up automatic testing.
 
 .. literalinclude:: ../examples/openfoam_supersonic_wedge.py
    :pyobject: main


### PR DESCRIPTION
Corrects an error in the supersonic wedge documentation formatting.

Updates the supersonic wedge example to allow faster testing times by running less iterations during testing.

Ignore the random closed issue that I referenced in one of the commit messages.

Fixes #26 